### PR TITLE
release: 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-renderer-pug",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Pug renderer plugin for Hexo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Tested with https://github.com/hexojs/site (after renaming all *.jade to *.pug).