### PR TITLE
feat: load a JS config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,19 @@ Add support for [Pug].
 $ npm install hexo-renderer-pug --save
 ```
 
+## Config
+PugJS [options](https://pugjs.org/api/reference.html#options) are supported. These are the options passed into [compile()](https://pugjs.org/api/reference.html#pugcompilesource-options).
+
+Create a `pug.config.js` in your project root:
+
+```js
+module.exports = {
+  compile: {  // Passed to compile().
+    basedir: process.cwd(),
+    // ...Other options.
+  }
+  // No other methods are supported for now.
+}
+```
+
 [Pug]: http://pugjs.org/

--- a/lib/pug.js
+++ b/lib/pug.js
@@ -6,13 +6,15 @@ const pug = require('pug');
 const configPath = path.join(process.cwd(), 'pug.config');
 const defaultConfig = { compile: {} }; // avoids key errors
 
-let config;
+let hasConfig = true;
 try {
   // require might fail
-  config = { ...defaultConfig, ...require(configPath) };
+  require.resolve(configPath);
 } catch {
-  config = defaultConfig;
+  hasConfig = false;
 }
+
+const config = hasConfig ? require(configPath) : defaultConfig;
 
 function pugCompile(data) {
   const opts = {

--- a/lib/pug.js
+++ b/lib/pug.js
@@ -4,21 +4,21 @@ const path = require('path');
 const pug = require('pug');
 
 const configPath = path.join(process.cwd(), 'pug.config');
-const defaultConfig = { compile: {} } // avoids key errors
+const defaultConfig = { compile: {} }; // avoids key errors
 
-let config
+let config;
 try {
   // require might fail
-  config =  { ...defaultConfig, ...require(configPath) }
+  config = { ...defaultConfig, ...require(configPath) };
 } catch {
-  config = defaultConfig
+  config = defaultConfig;
 }
 
 function pugCompile(data) {
-  let opts = {
+  const opts = {
     ...config.compile,
     filename: data.path // always used
-  }
+  };
   return pug.compile(data.text, opts);
 }
 

--- a/lib/pug.js
+++ b/lib/pug.js
@@ -8,13 +8,18 @@ const defaultConfig = { compile: {} }; // avoids key errors
 
 let hasConfig = true;
 try {
-  // require might fail
   require.resolve(configPath);
 } catch {
   hasConfig = false;
 }
 
 const config = hasConfig ? require(configPath) : defaultConfig;
+
+const hasProp = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
+const invalidKeys = Object.keys(config).filter(k => !hasProp(defaultConfig, k));
+if (invalidKeys.length > 0) {
+  throw Error(`Unsupported PUG config keys: ${invalidKeys.join(', ')}`);
+}
 
 function pugCompile(data) {
   const opts = {

--- a/lib/pug.js
+++ b/lib/pug.js
@@ -15,6 +15,7 @@ try {
 
 const config = hasConfig ? require(configPath) : defaultConfig;
 
+// Validate non-standard keys -- e.g. 'compile'.
 const hasProp = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
 const invalidKeys = Object.keys(config).filter(k => !hasProp(defaultConfig, k));
 if (invalidKeys.length > 0) {

--- a/lib/pug.js
+++ b/lib/pug.js
@@ -1,11 +1,25 @@
 'use strict';
 
+const path = require('path');
 const pug = require('pug');
 
+const configPath = path.join(process.cwd(), 'pug.config');
+const defaultConfig = { compile: {} } // avoids key errors
+
+let config
+try {
+  // require might fail
+  config =  { ...defaultConfig, ...require(configPath) }
+} catch {
+  config = defaultConfig
+}
+
 function pugCompile(data) {
-  return pug.compile(data.text, {
-    filename: data.path
-  });
+  let opts = {
+    ...config.compile,
+    filename: data.path // always used
+  }
+  return pug.compile(data.text, opts);
 }
 
 function pugRenderer(data, locals) {


### PR DESCRIPTION
Load a JS config file from the root directory. I chose JS so that users can set dynamic values (e.g. `basedir: process.cwd()`) -- which allows them to set a base directory for include (absolute) paths (i.e. avoid '../../../foo').

I also created the config in a way that is extensible in the future, so keys for different methods can be used if that need arises (meaning that no breaking changes required).